### PR TITLE
fix HTTPS clone URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Abbreviations
 Get the Source Code
 -------------------
 
-Clone the Git repository `git clone https://github.com/sap/cloud-sfsf-benefits-ext.git`, or [download the latest release](https://github.com/sap/cloud-sfsf-benefits-ext/zipball/master).
+Clone the Git repository `git clone https://github.com/SAP/cloud-sfsf-benefits-ext.git`, or [download the latest release](https://github.com/sap/cloud-sfsf-benefits-ext/zipball/master).
 
 In Eclipse import as *Existing Maven Project* and point to the *pom.xml* file located in *com.sap.hana.cloud.samples.benefits* folder.
 


### PR DESCRIPTION
GitHub git server seems to handle repository paths in a case-sensitive
way.
